### PR TITLE
Disable confirmation handler (for now)

### DIFF
--- a/lib/Zureg/Main/Lambda.hs
+++ b/lib/Zureg/Main/Lambda.hs
@@ -90,11 +90,18 @@ main = do
                     registrant <- Database.getRegistrant db uuid
                     html $ Views.scan registrant
 
+            {-
+
+            NOTE (jaspervdj): We only want to enable this confirmation button
+            handler when send out the confirmation email.
+
             ["confirm"] -> do
                 uuid <- getUuidParam req
                 Database.writeEvents db uuid [Confirm]
                 return $ Serverless.response302 $
                     "ticket?uuid=" <> E.uuidToText uuid
+
+            -}
 
             ["cancel"] -> do
                 (view, mbCancel) <- Serverless.runForm req "cancel" $

--- a/lib/Zureg/Views.hs
+++ b/lib/Zureg/Views.hs
@@ -121,12 +121,20 @@ ticket r@Registrant {..} = template
                 H.input H.! A.type_ "submit"
                     H.! A.value "Take me back to the registration"
 
+        {-
+
+        NOTE (jaspervdj): The following snippet of code shows the "confirmation"
+        button.  We will want to enable this as soon we as we send out the
+        confirmation reminder to all attendees.
+
         unless (rState == Just Confirmed || rState == Just Cancelled) $
             H.form H.! A.method "GET" H.! A.action "confirm" $ do
                 H.input H.! A.type_ "hidden" H.! A.name "uuid"
                     H.! A.value (H.toValue (E.uuidToText rUuid))
                 H.input H.! A.type_ "submit"
                     H.! A.value "Confirm my registration and access ticket"
+
+        -}
 
         unless (rState == Just Cancelled) $
             H.form H.! A.method "GET" H.! A.action "cancel" $ do


### PR DESCRIPTION
We will re-enable this when we send out the confirmation reminder