### PR TITLE
Fix "ask me about" field in form

### DIFF
--- a/lib/Zureg/Form.hs
+++ b/lib/Zureg/Form.hs
@@ -116,7 +116,7 @@ registerView recaptcha view = DH.form view "?" $ do
     H.p $ do
         "Topic(s) that you want to display on your badge.  It's a good ice "
         "breaker for people who want to chat with you."
-    DH.inputText "affiliation" view
+    DH.inputText "askMeAbout" view
     H.br
 
     H.p $ H.strong "Track Interest (optional)"


### PR DESCRIPTION
The identifier was wrong and we didn't notice this because it was optional.

This means that unfortunately we never stored this information in
the database.