### PR TITLE
Use nonroot user and enhance entrypoint handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,4 @@ RUN chmod 777 /build
 ENV HOME="/build"
 ENV STACK_WORK=".stack-work-docker"
 WORKDIR /build
-USER 1000
 ENTRYPOINT ["/bin/bash", "-l"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ RUN chmod 777 /build
 ENV HOME="/build"
 ENV STACK_WORK=".stack-work-docker"
 WORKDIR /build
-ENTRYPOINT /bin/bash -l
+USER 1000
+ENTRYPOINT ["/bin/bash", "-l"]

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docker:
 		-it \
 		-m 4GB \
 		-p 8080:8080 \
-		--user $(shell id -u):$(shell id -g) \
+		--user 1000:1000 \
 		--mount type=bind,source=$(shell pwd),target=/build \
 		--name zureg01 \
 		haskell-amazon-linux || \

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docker:
 		-it \
 		-m 4GB \
 		-p 8080:8080 \
-		--user 1000:1000 \
+		--user $(shell id -u):$(shell id -g) \
 		--mount type=bind,source=$(shell pwd),target=/build \
 		--name zureg01 \
 		haskell-amazon-linux || \


### PR DESCRIPTION
As of now, the container is running with `root` user: 

```
$ docker run -it --rm zureg
$ bash-4.2# whoami
$ root
$ bash-4.2# echo $HOME
$ /build 
```
Best Practice is to specify a nonroot user with `UID` >= 0.  A dedicated `USER` command is solving this issue. Also some minor refactoring in terms of `ENTRYPOINT`, e. g. see [here](https://www.ctl.io/developers/blog/post/dockerfile-entrypoint-vs-cmd/)