### PR TITLE
QR Code scaling

### DIFF
--- a/lib/Zureg/Views.hs
+++ b/lib/Zureg/Views.hs
@@ -207,10 +207,11 @@ qrimg qrdata = fromMaybe "Could not generate QR code" $ do
     version <- QRCode.version 2
     matrix  <- QRCode.encode version QRCode.L QRCode.Alphanumeric qrdata
     let array = QRCode.toArray matrix :: Array.Array (Int, Int) JP.Pixel8
+        moduleSize = 16 -- QR-Code version 2 has 25x25 modules, so this amounts to an image size of 400px
         image = JP.generateImage
-            (\x y -> array Array.! (x, y))
-            (QRCode.width matrix + 1)
-            (QRCode.width matrix + 1)
+            (\x y -> array Array.! (x `div` moduleSize, y `div` moduleSize))
+            (moduleSize * (QRCode.width matrix + 1))
+            (moduleSize * (QRCode.width matrix + 1))
 
         base64 = Base64.encode $ JP.encodePng image
         src    = "data:image/png;base64," <> H.unsafeLazyByteStringValue base64


### PR DESCRIPTION
Each QR field is 16x16px (instead of 1x1) ⇒ total image size is 400px (at QR version 2, i.e. 25x25 modules)

Fixes #42