### PR TITLE
Janitor & Summaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build: build/zureg-lambda.zip
 
 # We need docker to build binaries that run on amazon's linux version, which is
 # why this command is a bit more complicated than just `stack install`.
-build/bin/zureg-lambda: build/image.txt $(SOURCES)
+build/bin/zureg-web: build/image.txt $(SOURCES)
 	mkdir -p build/bin
 	docker run \
 		-m 4GB \
@@ -21,11 +21,12 @@ build/bin/zureg-lambda: build/image.txt $(SOURCES)
 	touch $@
 
 # Put all code and dependencies in a zip file we can run on AWS Lambda.
-build/zureg-lambda.zip: build/bin/zureg-lambda deploy/main.py deploy/env.json
+build/zureg-lambda.zip: build/bin/zureg-web deploy/main.py deploy/env.json
 	mkdir -p build/zureg-lambda
-	ln -fs $(PWD)/build/bin/zureg-lambda build/zureg-lambda/hsmain
-	ln -fs $(PWD)/deploy/main.py         build/zureg-lambda/main.py
-	ln -fs $(PWD)/deploy/env.json        build/zureg-lambda/env.json
+	ln -fs $(PWD)/build/bin/zureg-janitor build/zureg-lambda/zureg-janitor
+	ln -fs $(PWD)/build/bin/zureg-web 	  build/zureg-lambda/zureg-web
+	ln -fs $(PWD)/deploy/main.py      	  build/zureg-lambda/main.py
+	ln -fs $(PWD)/deploy/env.json     	  build/zureg-lambda/env.json
 	zip $@ -j build/zureg-lambda/*
 	ls -lh $@
 

--- a/deploy/main.py
+++ b/deploy/main.py
@@ -35,16 +35,21 @@ class Process:
 
     return response
 
-hsmain: Optional[Process] = None
+processes: Dict[str, Process] = {}
 
-def handler(event: dict, context: dict) -> dict:
-  global hsmain
+def get_process(name: str) -> Process:
+  if name in processes:
+    return processes[name]
 
-  if not hsmain:
-    with open('env.json') as f:
-      env: Dict[str, str] = json.loads(f.read())
+  with open('env.json') as f:
+    env: Dict[str, str] = json.loads(f.read())
 
-    binary = os.environ['LAMBDA_TASK_ROOT'] + '/hsmain'
-    hsmain = Process([binary], env)
+  binary = os.environ['LAMBDA_TASK_ROOT'] + '/' + name
+  processes[name] = Process([binary], env)
+  return processes[name]
 
-  return hsmain.handler(event)
+def web_handler(event: dict, context: dict) -> dict:
+  return get_process('zureg-web').handler(event)
+
+def janitor_handler(event: dict, context: dict) -> dict:
+  return get_process('zureg-janitor').handler(event)

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -7,7 +7,8 @@ Parameters:
 
 Resources:
   # This table stores participant registration using event sourcing: we only
-  # store events.
+  # store events.  This is the only table that can be considered the ground
+  # truth; the other tables are derived from events in this table.
   RegDatabase:
     Type: 'AWS::DynamoDB::Table'
     DeletionPolicy: 'Retain'
@@ -42,6 +43,22 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: 3
         WriteCapacityUnits: 3
+
+  # This holds the number of registrants and other statistics.
+  SummariesDatabase:
+    Type: 'AWS::DynamoDB::Table'
+    DeletionPolicy: 'Delete'
+    Properties:
+      TableName: 'summaries'
+      AttributeDefinitions:
+      - AttributeName: 'name'
+        AttributeType: 'S'
+      KeySchema:
+      - AttributeName: 'name'
+        KeyType: 'HASH'
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 2
 
   # This is the lambda we deploy.  It says Python but it's really just a
   # simple wrapper around a Haskell binary.

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -72,8 +72,7 @@ Resources:
   ZuregLambda:
     Type: 'AWS::Lambda::Function'
     Properties:
-      # TODO(jaspervdj): This should be renamed to 'zureg-web'.
-      FunctionName: 'zureg-lambda'
+      FunctionName: 'zureg-web'
       Handler: 'main.web_handler'
       Role: {'Fn::GetAtt': ['LambdaExecutionRole', 'Arn']}
       Runtime: 'python3.6'

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -84,6 +84,9 @@ Resources:
 
   # This is the role of the lambda: the permissions it needs.  We need access to
   # logs, and to the database.
+  #
+  # TODO(jaspervdj): Possibly we can split this up into a web role and a janitor
+  # role.
   LambdaExecutionRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -102,11 +105,14 @@ Resources:
           Version: '2012-10-17'
           Statement:
           - Effect: 'Allow'
-            Action: ['dynamodb:PutItem', 'dynamodb:Query']
+            Action: ['dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:Scan']
             Resource: {'Fn::GetAtt': ['RegDatabase', 'Arn']}
           - Effect: 'Allow'
             Action: ['dynamodb:PutItem', 'dynamodb:Query', 'dynamodb:DeleteItem']
             Resource: {'Fn::GetAtt': ['EmailDatabase', 'Arn']}
+          - Effect: 'Allow'
+            Action: ['dynamodb:PutItem']
+            Resource: {'Fn::GetAtt': ['SummariesDatabase', 'Arn']}
           - Effect: 'Allow'
             Action: ['ses:SendEmail']
             Resource: {'Fn::Sub': 'arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${EmailAddress}'}
@@ -165,3 +171,21 @@ Resources:
       Code:
         S3Bucket: {'Ref': 'SourceS3Bucket'}
         S3Key: {'Ref': 'SourceS3Key'}
+
+  JanitorRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: 'Invoke the zureg janitor regularly'
+      ScheduleExpression: 'rate(4 hours)'
+      State: 'ENABLED'
+      Targets:
+      - Arn: {'Fn::GetAtt': ['JanitorLambda', 'Arn']}
+        Id: 'JanitorTarget'
+
+  JanitorInvokePermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: {'Fn::GetAtt': ['JanitorLambda', 'Arn']}
+      Principal: 'events.amazonaws.com'
+      SourceArn: {'Fn::GetAtt': ['JanitorRule', 'Arn']}

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -67,11 +67,14 @@ Resources:
 
   # This is the lambda we deploy.  It says Python but it's really just a
   # simple wrapper around a Haskell binary.
+  #
+  # TODO(jaspervdj): This should be renamed to 'WebLambda'.
   ZuregLambda:
     Type: 'AWS::Lambda::Function'
     Properties:
+      # TODO(jaspervdj): This should be renamed to 'zureg-web'.
       FunctionName: 'zureg-lambda'
-      Handler: 'main.handler'
+      Handler: 'main.web_handler'
       Role: {'Fn::GetAtt': ['LambdaExecutionRole', 'Arn']}
       Runtime: 'python3.6'
       Timeout: 10
@@ -92,14 +95,13 @@ Resources:
           Principal: {'Service': ['lambda.amazonaws.com']}
           Action: ['sts:AssumeRole']
       Path: '/'
+      ManagedPolicyArns:
+      - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
       Policies:
       - PolicyName: 'root'
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
-          - Effect: 'Allow'
-            Action: ['logs:*']
-            Resource: 'arn:aws:logs:*:*:*'
           - Effect: 'Allow'
             Action: ['dynamodb:PutItem', 'dynamodb:Query']
             Resource: {'Fn::GetAtt': ['RegDatabase', 'Arn']}
@@ -110,7 +112,9 @@ Resources:
             Action: ['ses:SendEmail']
             Resource: {'Fn::Sub': 'arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${EmailAddress}'}
 
-  # Allow ApiGateway to invoke the function
+  # Allow ApiGateway to invoke the function.
+  #
+  # TODO(jaspervdj): This should be renamed to 'WebLambdaPermission'.
   LambdaPermission:
     Type: 'AWS::Lambda::Permission'
     Properties:
@@ -149,3 +153,16 @@ Resources:
     Properties:
       RestApiId: {'Ref': 'Api'}
       StageName: 'beta'
+
+  JanitorLambda:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      FunctionName: 'zureg-janitor'
+      Handler: 'main.janitor_handler'
+      Role: {'Fn::GetAtt': ['LambdaExecutionRole', 'Arn']}
+      Runtime: 'python3.6'
+      Timeout: 10
+      MemorySize: 512  # If not, requests to DDB time out...
+      Code:
+        S3Bucket: {'Ref': 'SourceS3Bucket'}
+        S3Key: {'Ref': 'SourceS3Key'}

--- a/lib/Zureg/Hackathon/ZuriHac2019.hs
+++ b/lib/Zureg/Hackathon/ZuriHac2019.hs
@@ -38,8 +38,8 @@ newHackathon = do
             { SendEmail.cFrom = "ZuriHac Registration Bot <" <> email <> ">"
             }
         , Hackathon.reCaptchaConfig = ReCaptcha.Config
-            { ReCaptcha.cEnabled = True
-            , ReCaptcha.cSiteKey = "6LcVUm8UAAAAAL0ooPLkNT3O9oEXhGPK6kZ-hQk7"
+            { ReCaptcha.cEnabled   = False
+            , ReCaptcha.cSiteKey   = "6LcVUm8UAAAAAL0ooPLkNT3O9oEXhGPK6kZ-hQk7"
             , ReCaptcha.cSecretKey = reCaptchaSecret
             }
         , Hackathon.scannerSecret = scannerSecret

--- a/lib/Zureg/Lambda.hs
+++ b/lib/Zureg/Lambda.hs
@@ -1,0 +1,60 @@
+-- | Low-ish level module to talk to AWS Lambda.  A Python process spawns a
+-- binary and sends events to us; one line of JSON at a time.  We respond by
+-- writing back JSON.
+module Zureg.Lambda
+    ( LambdaException (..)
+    , main
+    ) where
+
+import qualified Control.Concurrent.Async   as Async
+import           Control.Exception          (Exception, SomeException, throwIO)
+import qualified Data.Aeson                 as A
+import qualified Data.ByteString            as B
+import qualified Data.ByteString.Lazy       as BL
+import qualified Data.ByteString.Lazy.Char8 as BL8
+import qualified System.IO                  as IO
+
+data LambdaException
+    = ParseInputJsonException String
+
+instance Show LambdaException where
+    show (ParseInputJsonException str) = "Could not parse input JSON: " ++ str
+
+instance Exception LambdaException
+
+main
+    :: (A.FromJSON request, A.ToJSON response)
+    => IO.Handle
+    -- ^ Input handle, usually stdin
+    -> IO.Handle
+    -- ^ Output handle, usually stdout
+    -> (SomeException -> response)
+    -- ^ Generate an error response, used on exceptions
+    -> (request -> IO response)
+    -- ^ Generate a normal response
+    -> IO ()
+main ih oh errorResponse normalResponse =
+    loop
+  where
+    loop = do
+        eof <- IO.hIsEOF ih
+        if eof
+            then return ()
+            else do
+                input <- B.hGetLine ih
+                output <- respond input
+                BL.hPutStr oh output
+                BL8.hPutStrLn oh BL8.empty
+                IO.hFlush oh
+                loop
+
+    respond :: B.ByteString -> IO BL.ByteString
+    respond input = do
+        thread <- Async.async $ case A.eitherDecode' (BL.fromChunks [input]) of
+            Right x  -> normalResponse x
+            Left err -> throwIO $ ParseInputJsonException err
+
+        errOrRsp <- Async.waitCatch thread
+        case errOrRsp of
+            Right r -> return $ A.encode r
+            Left  e -> return $ A.encode $ errorResponse e

--- a/lib/Zureg/Main/Janitor.hs
+++ b/lib/Zureg/Main/Janitor.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Zureg.Main.Janitor
+    ( main
+    ) where
+
+import qualified Data.Aeson      as A
+import qualified System.IO       as IO
+import qualified Zureg.Database  as Database
+import           Zureg.Hackathon (Hackathon)
+import qualified Zureg.Hackathon as Hackathon
+import qualified Zureg.Lambda    as Lambda
+
+
+--------------------------------------------------------------------------------
+-- The request and response types for the janitor lambda are mostly ignored,
+-- it's just a thing that runs from time to time.
+
+data Request = Request
+
+instance A.FromJSON Request where
+    parseJSON _ = pure Request
+
+data Response
+    = MessageResponse String
+    | ErrorResponse   String
+
+instance A.ToJSON Response where
+    toJSON (MessageResponse msg) = A.object ["message" A..= msg]
+    toJSON (ErrorResponse   err) = A.object ["error"   A..= err]
+
+
+main :: forall a. (A.FromJSON a, A.ToJSON a) => Hackathon a -> IO ()
+main hackathon =
+    Database.withHandle (Hackathon.databaseConfig hackathon) $ \_db ->
+    Lambda.main IO.stdin IO.stdout (ErrorResponse . show) $ \Request ->
+    pure $ MessageResponse "Hi, I'm the janitor!"

--- a/lib/Zureg/Main/Web.hs
+++ b/lib/Zureg/Main/Web.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-module Zureg.Main.Lambda
+module Zureg.Main.Web
     ( main
     ) where
 

--- a/src/Janitor.hs
+++ b/src/Janitor.hs
@@ -1,0 +1,5 @@
+import qualified Zureg.Hackathon
+import qualified Zureg.Main.Janitor
+
+main :: IO ()
+main = Zureg.Hackathon.withHackathonFromEnv Zureg.Main.Janitor.main

--- a/src/Lambda.hs
+++ b/src/Lambda.hs
@@ -1,5 +1,0 @@
-import qualified Zureg.Hackathon
-import qualified Zureg.Main.Lambda
-
-main :: IO ()
-main = Zureg.Hackathon.withHackathonFromEnv Zureg.Main.Lambda.main

--- a/src/Web.hs
+++ b/src/Web.hs
@@ -1,0 +1,5 @@
+import qualified Zureg.Hackathon
+import qualified Zureg.Main.Web
+
+main :: IO ()
+main = Zureg.Hackathon.withHackathonFromEnv Zureg.Main.Web.main

--- a/zureg.cabal
+++ b/zureg.cabal
@@ -38,10 +38,12 @@ Library
     Zureg.Hackathon.ZuriHac2019.Form
     Zureg.Hackathon.ZuriHac2019.Model
     Zureg.Hackathon.ZuriHac2019.Views
+    Zureg.Lambda
     Zureg.Main.Badges
     Zureg.Main.Email
     Zureg.Main.Export
-    Zureg.Main.Lambda
+    Zureg.Main.Janitor
+    Zureg.Main.Web
     Zureg.Main.PopWaitlist
     Zureg.Model
     Zureg.Model.Csv
@@ -102,9 +104,9 @@ Executable zureg-export
   Import:  exe
   Main-is: Export.hs
 
-Executable zureg-lambda
+Executable zureg-web
   Import:  exe
-  Main-is: Lambda.hs
+  Main-is: Web.hs
 
 Executable zureg-email
   Import:  exe
@@ -121,3 +123,7 @@ Executable zureg-pop-waitlist
 Executable zureg-badges
   Import:  exe
   Main-is: Badges.hs
+
+Executable zureg-janitor
+  Import:  exe
+  Main-is: Janitor.hs


### PR DESCRIPTION
The goal of this PR is to provide a new `summaries` table that holds the number
of registrants, waitlisted people, etc.  A cronjob-style CloudWatch event triggers
a Janitor Lambda to keep this table up to date.

Once this table is populated, we will be able to build on top of this work to add
automatic waitlist processing.