### PR TITLE
Small fixes to waiting list

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -30,7 +30,7 @@ Resources:
       - AttributeName: 'version'
         KeyType: 'RANGE'
       ProvisionedThroughput:
-        ReadCapacityUnits: 3
+        ReadCapacityUnits: 6
         WriteCapacityUnits: 3
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true

--- a/lib/Zureg/Hackathon/ZuriHac2020.hs
+++ b/lib/Zureg/Hackathon/ZuriHac2020.hs
@@ -25,7 +25,7 @@ newHackathon = do
         , Hackathon.baseUrl = "https://zureg.zfoh.ch"
         , Hackathon.contactUrl = "https://zfoh.ch/zurihac2020/#contact"
         , Hackathon.slackUrl = "https://slack.zurihac.info/"
-        , Hackathon.capacity = 500
+        , Hackathon.capacity = 550
         , Hackathon.confirmation = False
 
         , Hackathon.registerForm = ZH20.additionalInfoForm

--- a/lib/Zureg/Main/Web.hs
+++ b/lib/Zureg/Main/Web.hs
@@ -50,9 +50,7 @@ main hackathon =
                         registerForm
                         (Hackathon.registerForm hackathon))
                 registrantsSummary <- Database.lookupRegistrantsSummary db
-                let atCapacity = Database.rsTotal registrantsSummary
-                                   >= Hackathon.capacity hackathon
-
+                let atCapacity = Database.rsAvailable registrantsSummary <= 0
                 case mbReg of
                     Nothing -> html $
                         Views.register hackathon (ReCaptcha.clientHtml recaptcha) view


### PR DESCRIPTION
 -  Increase read capacity of registrants table to prevent janitor from
    reaching said capacity
 -  Don't count cancelled attendees when calculating `atCapacity`
 -  Bump ZuriHac 2020 capacity to 550