### PR TITLE
Allow deployment outside us-central-1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ build/bucket.txt:
 	aws s3api create-bucket \
 		--profile $(AWS_PROFILE) \
 		--region $(AWS_REGION) \
-		--bucket $(BUCKET)
+		--bucket $(BUCKET) \
+		--create-bucket-configuration LocationConstraint=${AWS_REGION}
 	echo $(BUCKET) >$@
 
 # A text file with the name of the zip file with the lambda's code.  Similarly

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ This application needs to be compiled on two different platforms:
     to the "invoke URL" followed by `/register`.  You should now see the
     registration page.
 
+    If you see `NotFoundException registrants summary` instead. make sure to run
+    the `zureg-janitor` lambda once to bootstrap the summary.
+
 5.  As a test, register using an email address you verified (by default, AWS
     will not let you send email to random people).
 


### PR DESCRIPTION
Several binaries did not pick up the AWS region correctly, making it impossible to use Zureg outside of us-central-1.
Changes:
* S3 buckets are created in the region where Zureg is deployed, rather than in us-central-1.
* For the local binaries (zureg-export, zureg-email, etc.), the AWS region is now correctly picked up from the environment variable (previously, this was working for the Lambdas b/c of EC2 credentials handling, but not locally).
* Drive-by addition: After the first deployment, it is necessary to run the janitor once, otherwise registration does not work.