### PR TITLE
Add Africa to registration form's regions

### DIFF
--- a/lib/Zureg/Hackathon/ZuriHac2021/Model.hs
+++ b/lib/Zureg/Hackathon/ZuriHac2021/Model.hs
@@ -25,6 +25,7 @@ data Region
     | CentralAmerica
     | SouthAmerica
     | Oceania
+    | Africa
     deriving (Bounded, Enum, Eq, Show)
 
 data ContributorLevel = ContributorLevel


### PR DESCRIPTION
I noticed Africa was missing  as a region in the registration form.